### PR TITLE
fix: correct typo and remove duplicate dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ streamlit run SingleEngineApp/insight_engine_streamlit_app.py --server.port 8501
 
 #### 5.3 爬虫系统单独使用
 
-这部分有详细的配置文档：[MindeSpider使用说明](./MindSpider/README.md)
+这部分有详细的配置文档：[MindSpider使用说明](./MindSpider/README.md)
 
 <div align="center">
 <img src="MindSpider\img\example.png" alt="banner" width="600">

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,4 +73,3 @@ flake8>=6.0.0
 # ===== Web服务器 =====
 fastapi==0.110.2
 uvicorn==0.29.0
-loguru


### PR DESCRIPTION
 ## Summary
This PR fixes two small issues:

  1. **Fixed typo in README.md**: Corrected `MindeSpider` to `MindSpider` (line 310)
  2. **Removed duplicate dependency**: Removed duplicate `loguru` entry in `requirements.txt` (line 76, keeping the version-constrained one at line 65)

  ## Changes
  - README.md: 1 character change
  - requirements.txt: 1 line removed

  ## Motivation
  - The typo could confuse users reading the documentation
  - Duplicate dependencies in requirements.txt may cause version management issues

  ## Testing
  - Verified the changes don't break existing functionality
  - Both files remain valid after modifications