### PR TITLE
fix: disable Streamlit file watcher to resolve torch.classes conflict

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     restart: unless-stopped
     environment:
       - PYTHONUNBUFFERED=1
+      - STREAMLIT_SERVER_ENABLE_FILE_WATCHER=false
     ports:
       - "5000:5000"
       - "8501:8501"


### PR DESCRIPTION
Streamlit file watcher triggers a runtime exception when inspecting `torch.classes`,
which is a C++ registry interface rather than a Python path.

Resolved by setting `STREAMLIT_SERVER_ENABLE_FILE_WATCHER=false`.

Tested in local + Docker environment. Fixes #215

Release Note:
- Disabled Streamlit file watcher to avoid `torch.classes` conflict (#215 ) 