### PR TITLE
fix(docker): Correct environment variable loading in docker-compose / 修复(docker): 修正 docker-compose 中的环境变量加载问题

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     # image: ghcr.nju.edu.cn/666ghj/bettafish:latest
     container_name: bettafish
     restart: unless-stopped
+    env_file:
+      - .env
     environment:
       - PYTHONUNBUFFERED=1
       - STREAMLIT_SERVER_ENABLE_FILE_WATCHER=false


### PR DESCRIPTION
# What's Changed

  This PR fixes a critical issue where environment variables from the .env file were not being correctly
  loaded by the services when running docker-compose up.

# How was this fixed?

  The following changes were made to docker-compose.yml:

   * For the `bettafish` service:
       * Added the env_file: - .env directive to ensure it loads all required environment variables from the
         .env file.
  
---

# 修复了什么

  本 PR 修复了一个关键问题：在使用 docker-compose up 启动时，服务无法从 .env 文件中正确加载环境变量。

# 如何修复的？
  对 docker-compose.yml 文件进行了如下修改：

   * 针对 `bettafish` 服务:
       * 添加了 env_file: - .env 指令，以确保它能从 .env 文件加载所有必要的环境变量。
