### PR TITLE
fix: correctly load environment variables in docker-compose / fix: docker-compose 修复部署时网页无env配置

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./final_reports:/app/final_reports
+      - ./.env:/app/.env  
       - ./insight_engine_streamlit_reports:/app/insight_engine_streamlit_reports
       - ./media_engine_streamlit_reports:/app/media_engine_streamlit_reports
       - ./query_engine_streamlit_reports:/app/query_engine_streamlit_reports


### PR DESCRIPTION
## What's Changed

This PR fixes a critical issue where environment variables from the .env file were not being correctly loaded by the bettafish service when running docker-compose up.

## How was this fixed?

The following changes were made to docker-compose.yml:

**For the bettafish service:**

Added volume mount `- ./.env:/app/.env` to the bettafish service, enabling bidirectional synchronization between the web interface and the .env file (unlike `env_file` which only supports one-way loading).

## 如何修复的？

---

## 修复了什么

本 PR 修复了一个关键问题：在使用 docker-compose up 启动时，bettafish 服务无法从 .env 文件中正确加载环境变量。

## 如何修复的？

对 docker-compose.yml 文件进行了如下修改：

**针对 bettafish 服务：**
添加了卷挂载 `- ./.env:/app/.env`，确保服务能够从容器内的 .env 文件读取环境变量。实现了网页界面与 .env 文件的双向同步（与仅支持单向加载的 `env_file` 不同）。

PS：修复不会导致配置内修改配置的方式无效。