### PR TITLE
Avoid Using Port 5000 on macOS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - PYTHONUNBUFFERED=1
       - STREAMLIT_SERVER_ENABLE_FILE_WATCHER=false
     ports:
-      - "5000:5000"
+      - "5001:5000"
       - "8501:8501"
       - "8502:8502"
       - "8503:8503"


### PR DESCRIPTION
Please don’t use port 5000. On macOS, port 5000 is used by AirPlay and AirDrop, 和 it cannot be fully disabled even via the command line. Simply change to a different port and it will work.